### PR TITLE
Adding support for #links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,42 @@
-import React, { Component } from "react"
+import React, { Component } from "react";
 import { BrowserRouter, Route } from "react-router-dom";
-import "./App.css"
-import LandingPage from './containers/LandingPage.js'
-import HackShackCarousel from './containers/HackShackCarousel.js'
+import "./App.css";
+import LandingPage from "./containers/LandingPage.js";
+import HackShackCarousel from "./containers/HackShackCarousel.js";
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      initDayFilter: window.location.hash ? "all" : 18
+    };
+  }
+
+  hashLinkScroll = () => {
+    const { hash } = window.location;
+    if (hash !== "") {
+      setTimeout(() => {
+        const id = hash.replace("#", "");
+        const el = document.getElementById(id);
+        if (el) el.scrollIntoView();
+      }, 500);
+    }
+  };
+
   render() {
     return (
-      <BrowserRouter>
-            <Route exact path="/" component= {LandingPage}/>
-            <Route  exact path="/hackshack" component={HackShackCarousel} />
+      <BrowserRouter onUpdate={this.hashLinkScroll()}>
+        <Route
+          exact
+          path="/"
+          render={props => (
+            <LandingPage {...props} day={this.state.initDayFilter} />
+          )}
+        />
+        <Route exact path="/hackshack" component={HackShackCarousel} />
       </BrowserRouter>
-    )
+    );
   }
 }
 
-export default App
+export default App;

--- a/src/components/CardLayout/index.js
+++ b/src/components/CardLayout/index.js
@@ -20,6 +20,7 @@ const handleClick = (action, label) => {
 };
 
 export const CardLayout = ({
+  id,
   image,
   title,
   page,
@@ -34,6 +35,7 @@ export const CardLayout = ({
   ...rest
 }) => (
   <Box
+    id={id}
     pad={{ top: "small", bottom: "medium" }}
     margin="small"
     direction="row-responsive"

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -12,8 +12,8 @@ export default class LandingPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selected: 18,
-      sessions: this.filterSessions(eventSchedule, 18)
+      selected: this.props.day || 18,
+      sessions: this.filterSessions(eventSchedule, this.props.day || 18)
     };
     this.onClick = this.onClick.bind(this);
   }
@@ -27,7 +27,7 @@ export default class LandingPage extends Component {
       gaDebug = false;
     } else if (process.env.NODE_ENV === "development") {
       gtagId = "UA-NNNNNN-N";
-      gaDebug = true;
+      gaDebug = false;
     } else {
       throwError(
         "NODE_ENV not set to 'production' nor 'development'." +
@@ -49,11 +49,17 @@ export default class LandingPage extends Component {
 
   filterSessions(sessions, day) {
     return sessions
-      .filter(session =>
-        day === undefined
-          ? session.datetimeStart === undefined
-          : new Date(session.datetimeStart).getDate() === day
-      )
+      .filter(session => {
+        if (day === undefined) {
+          return session.datetimeStart === undefined;
+        }
+        else if (day === "all") {
+          return session;
+        }
+        else {
+          return new Date(session.datetimeStart).getDate() === day;
+        }
+      })
       .sort((a, b) => {
         if (a.datetimeStart < b.datetimeStart) {
           return -1;
@@ -156,9 +162,11 @@ export default class LandingPage extends Component {
               videoLink,
               image,
               datetimeStart,
-              datetimeEnd
+              datetimeEnd,
+              hash_link,
             }) => (
               <TabLayout
+                id={hash_link}
                 key={id}
                 image={image === "" ? defaultImage : image}
                 title={title}

--- a/src/data/hpe-discover-events.json
+++ b/src/data/hpe-discover-events.json
@@ -102,8 +102,7 @@
     "datetimeStart": "2019-06-20T15:00:00.000Z",
     "datetimeEnd": "2019-06-20T15:40:00.000Z",
     "presenter": "Dana Lynn",
-    "content": "Learn how insights from user experience research and design can improve the outcome of your product roadmap. In this session, we'll guide you through a multi-disciplinary approach to UX research and design strategy. Walk away with shared resources that will enable you to partake in the design journey with us. Everybody is welcome to attend this session.  ",
-    "hash_link": "oneviewapi"
+    "content": "Learn how insights from user experience research and design can improve the outcome of your product roadmap. In this session, we'll guide you through a multi-disciplinary approach to UX research and design strategy. Walk away with shared resources that will enable you to partake in the design journey with us. Everybody is welcome to attend this session.  "
   },
   {
     "id": "18598_9074",
@@ -118,7 +117,8 @@
     "datetimeStart": "2019-06-19T21:00:00.000Z",
     "datetimeEnd": "2019-06-19T21:40:00.000Z",
     "presenter": "Blaine Southam",
-    "content": "Bring your laptop, get comfortable and be ready to learn about HPE OneView, HPE's composable infrastructure management platform designed to help accelerate your customer outcomes. During our interactive session, we'll explore the API using Postman. After that, we will use PowerShell (or Python) to write a script that automates HPE OneView. By the end of the workshop, you will have written a simple example of infrastructure as code. All experience levels are welcome."
+    "content": "Bring your laptop, get comfortable and be ready to learn about HPE OneView, HPE's composable infrastructure management platform designed to help accelerate your customer outcomes. During our interactive session, we'll explore the API using Postman. After that, we will use PowerShell (or Python) to write a script that automates HPE OneView. By the end of the workshop, you will have written a simple example of infrastructure as code. All experience levels are welcome.",
+    "hash_link": "oneviewapi"
   },
   {
     "id": "19834_9253",

--- a/src/data/hpe-discover-events.json
+++ b/src/data/hpe-discover-events.json
@@ -102,7 +102,8 @@
     "datetimeStart": "2019-06-20T15:00:00.000Z",
     "datetimeEnd": "2019-06-20T15:40:00.000Z",
     "presenter": "Dana Lynn",
-    "content": "Learn how insights from user experience research and design can improve the outcome of your product roadmap. In this session, we'll guide you through a multi-disciplinary approach to UX research and design strategy. Walk away with shared resources that will enable you to partake in the design journey with us. Everybody is welcome to attend this session.  "
+    "content": "Learn how insights from user experience research and design can improve the outcome of your product roadmap. In this session, we'll guide you through a multi-disciplinary approach to UX research and design strategy. Walk away with shared resources that will enable you to partake in the design journey with us. Everybody is welcome to attend this session.  ",
+    "hash_link": "oneviewapi"
   },
   {
     "id": "18598_9074",
@@ -267,7 +268,8 @@
     "datetimeStart": "2019-06-19T20:00:00.000Z",
     "datetimeEnd": "2019-06-19T20:40:00.000Z",
     "presenter": "Shimrit Yacobi",
-    "content": "Are you ready to turn stunning designs into pixel-perfect accessible web applications? Join the Grommet core team and learn how you can start using Grommet to build class-leading web applications. All experience levels are welcome.  "
+    "content": "Are you ready to turn stunning designs into pixel-perfect accessible web applications? Join the Grommet core team and learn how you can start using Grommet to build class-leading web applications. All experience levels are welcome.  ",
+    "hash_link": "grommet"
   },
   {
     "id": "18597_8916",


### PR DESCRIPTION
We had a request today to support #links in URLs so that a presenter can refer to there session and say to their audience "you can find my slides and presentation by going to lv19.hpedev.io#oneviewapi" or equivalent.

This experience is preferable to "Go to lv19.hpedev.io, click Day2, scroll halfway down the page and find the session with my name."

1. Navigating to "localhost:port/" should render Day1 sessions.
1. Entering "localhost:port/#oneviewapi" should render all sessions and scroll to Blaine's OneView API session.
1. Entering "localhost:port/#grommet" should render all sessions and scroll to Shimi's Grommet session.
 